### PR TITLE
Add CMake support and clang-tidy integration

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,11 @@
+Checks: >
+  clang-analyzer-*,performance-*,modernize-*,
+  bugprone-*,readability-*
+
+WarningsAsErrors: ''
+HeaderFilterRegex: 'src/.*'
+FormatStyle: file
+CheckOptions:
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2025-08-29
+## [0.1.0] - 2025-08-30
 ### Added
 - Initial version with working MP3 playback via mpg123 and PortAudio
 - Clean project structure and README
-- .clang-format and .gitignore setup
 - CMake build system and custom find modules
-- License and documentation files
-- Project version tracking started
+- .clang-format and .gitignore setup
+- .clang-tidy static analysis config
+- License and CHANGELOG
+- Adopted semantic versioning (SemVer) with project version tracking
+- To-Do list entry for fixing audio glitches and investigating buffer underruns
 
 #### Features
 - Decodes MP3 to PCM and streams to default output device

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-08-29
+### Added
+- Initial version with working MP3 playback via mpg123 and PortAudio
+- Clean project structure and README
+- .clang-format and .gitignore setup
+- CMake build system and custom find modules
+- License and documentation files
+- Project version tracking started
+
+#### Features
+- Decodes MP3 to PCM and streams to default output device
+- Implements real-time playback with error handling
+- Uses dynamic buffer allocation based on MP3 format
+- Includes setup validation and cleanup logic
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,42 @@
+# CMakeLists.txt for mp3_audio_analyzer
+# This file configures the build system for the mp3 audio analyzer project.
+# It sets up the C++ standard, finds dependencies, and defines the executable target.
+
+cmake_minimum_required(VERSION 3.10)
+
+# Project setup
+project(mp3_audio_analyzer VERSION 0.1.0 LANGUAGES CXX)
+
+# C++17 standard required
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+# Add custom modules path
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+# Find dependencies
+find_package(MPG123 REQUIRED)
+find_package(PortAudio REQUIRED)
+
+# Source files
+set(SOURCES
+    src/main.cpp
+)
+
+# Build executable
+add_executable(mp3_analyzer ${SOURCES})
+
+# Link libraries
+target_link_libraries(mp3_analyzer
+    PRIVATE
+        ${MPG123_LIBRARIES}
+        ${PortAudio_LIBRARIES}
+)
+
+# Include headers
+target_include_directories(mp3_analyzer
+  PRIVATE
+    ${MPG123_INCLUDE_DIRS}
+    ${PortAudio_INCLUDE_DIRS}
+)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,14 @@ project(mp3_audio_analyzer VERSION 0.1.0 LANGUAGES CXX)
 # C++17 standard required
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Enable clang-tidy if installed
+find_program(CLANG_TIDY_EXE NAMES "clang-tidy")
+    if(CLANG_TIDY_EXE)
+        message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
+        set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE}")
+    endif()
 
 # Add custom modules path
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ project-root/
 
 ## To Do
 
+- [ ] Fix audio glitches
+- [ ] Investigate buffer underruns or latency issues
 - [ ] Refactor cleanup logic
 - [ ] Refactor error handling into reusable functions
 - [ ] Refactor audio logic into functions (e.g., InitMp3(), InitPortAudio())

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # MP3 Audio Analyzer (C++)
 
+**Language:** C++  
+**Version:** `v0.1.0`
+
 A real-time MP3 audio analyzer (in development) using [mpg123](https://www.mpg123.de/) and [PortAudio](http://www.portaudio.com/).
 
 Currently, the project plays back MP3 files while decoding them to raw PCM audio. Future versions will analyze the audio data in real-time and output the results (e.g., for audio-reactive graphics).
@@ -17,47 +20,47 @@ Currently, the project plays back MP3 files while decoding them to raw PCM audio
 
 ---
 
-## Build Instructions
+## Build Instructions (CMake)
 
-Make sure you have the development libraries installed:
+Make sure you have the required development tools:
 
 ```bash
 sudo apt update
-sudo apt install libmpg123-dev portaudio19-dev build-essential
+sudo apt install cmake libmpg123-dev portaudio19-dev build-essential
 ```
 
-Then from the project root, run:
+Then from the project root:
 
 ```bash
 mkdir -p build
-g++ src/main.cpp -lmpg123 -lportaudio -o build/mp3_analyzer
+cd build
+cmake ..
+cmake --build .
 ```
 
----
-
-## Usage
+This will produce the executable:
 
 ```bash
-build/mp3_analyzer
+./mp3_analyzer
 ```
-
-Make sure the MP3 file is located at:
-
-```bash
-assets/gradient_deep_performance_edit.mp3
-```
-
-You can adjust the file path inside main.cpp if needed.
 
 ---
 
 ## Dependencies
 
+- CMake ≥ 3.10 (build system)
 - libmpg123 for MP3 decoding
 - PortAudio for audio playback
-- C++ compiler (e.g., g++)
+- C++17-compatible compiler (e.g., g++, clang++)
+- Tested on Linux (Pop!_OS); Windows/macOS support planned
 
-Currently tested on Linux (Pop!_OS).
+---
+
+## Development Tools
+- clang-tidy for static code analysis
+- clang-format for consistent formatting
+
+These tools are used during development to help maintain code quality and consistency.
 
 ---
 
@@ -67,11 +70,15 @@ Currently tested on Linux (Pop!_OS).
 project-root/
 │
 ├── assets/
+├── cmake/
 ├── src/
 ├── third_party_licenses/
+├── CHANGELOG.md
+├── CMakeLists.txt
 ├── LICENSE
 ├── README.md
 ├── .clang-format
+├── .clang-tidy
 └── .gitignore
 ```
 
@@ -85,7 +92,7 @@ project-root/
 - [ ] Add FFTW 
 - [ ] Add real-time audio analysis
 - [ ] Add 60 fps update/print loop for analysis
-- [ ] Add CMake support
+- [x] Add CMake support
 - [ ] Add cross-platform compatibility (Windows/macOS)
 
 ---

--- a/cmake/FindMPG123.cmake
+++ b/cmake/FindMPG123.cmake
@@ -1,0 +1,19 @@
+# cmake/FindMPG123.cmake
+# Custom CMake module to find mpg123 library and headers
+
+# Find the directory containing mpg123.h
+find_path(MPG123_INCLUDE_DIR mpg123.h)
+
+# Find the mpg123 library file
+find_library(MPG123_LIBRARY NAMES mpg123)
+
+# Use standard CMake macro to handle 'found' logic
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(MPG123
+    REQUIRED_VARS MPG123_LIBRARY MPG123_INCLUDE_DIR)
+
+# If found, set variables for include directories and libraries
+if(MPG123_FOUND)
+    set(MPG123_LIBRARIES ${MPG123_LIBRARY})
+    set(MPG123_INCLUDE_DIRS ${MPG123_INCLUDE_DIR})
+endif()

--- a/cmake/FindPortAudio.cmake
+++ b/cmake/FindPortAudio.cmake
@@ -1,0 +1,19 @@
+# cmake/FindPORTAUDIO.cmake
+# Custom CMake module to find PortAudio library and headers
+
+# Find the directory containing portaudio.h
+find_path(PORTAUDIO_INCLUDE_DIR portaudio.h)
+
+# Find the PortAudio library file
+find_library(PORTAUDIO_LIBRARY NAMES portaudio)
+
+# Use standard CMake macro to handle 'found' logic
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(PortAudio
+    REQUIRED_VARS PORTAUDIO_LIBRARY PORTAUDIO_INCLUDE_DIR)
+
+# If found, set variables for include directories and libraries
+if(PortAudio_FOUND)
+    set(PortAudio_LIBRARIES ${PORTAUDIO_LIBRARY})
+    set(PortAudio_INCLUDE_DIRS ${PORTAUDIO_INCLUDE_DIR})
+endif()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,7 +44,7 @@ int main() {
   }
 
   // Open the MP3 file.
-  if (mpg123_open(decoder, "assets/gradient_deep_performance_edit.mp3") !=
+  if (mpg123_open(decoder, "../assets/gradient_deep_performance_edit.mp3") !=
       MPG123_OK) {
     std::cerr << "Failed to open file.\n";
 


### PR DESCRIPTION
**Added:**

- CMake build system support with custom find modules for mpg123 and PortAudio
- Conditional clang-tidy static analysis integration in `CMakeLists.txt`
- `.clang-tidy` config file
- Added initial `CHANGELOG.md` with v0.1.0 release notes

**Updated:**

- `README.md` with build instructions and dependencies

**Testing:**

- Verified successful build on Linux (Pop!_OS) using `cmake .. && cmake --build .`
- Confirmed clang-tidy runs automatically if installed