### PR TITLE
Refactor/code cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2025-08-30
+### Refactor
+- Refactored code for consistency (changed `frames` type to `size_t`)
+
+### Style
+- Improved code readability and error handling (e.g., separated variable declarations, replaced `NULL` with `nullptr`)
+
+### Documentation
+- Added comments explaining safe type conversion for MP3 sample rates
+- Removed language from README.md title for brevity
+
 ## [0.1.0] - 2025-08-30
 ### Added
 - Initial version with working MP3 playback via mpg123 and PortAudio

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Project setup
-project(mp3_audio_analyzer VERSION 0.1.0 LANGUAGES CXX)
+project(mp3_audio_analyzer VERSION 0.1.1 LANGUAGES CXX)
 
 # C++17 standard required
 set(CMAKE_CXX_STANDARD 17)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MP3 Audio Analyzer
 
 **Language:** C++  
-**Version:** `v0.1.0`
+**Version:** `v0.1.1`
 
 A real-time MP3 audio analyzer (in development) using [mpg123](https://www.mpg123.de/) and [PortAudio](http://www.portaudio.com/).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MP3 Audio Analyzer (C++)
+# MP3 Audio Analyzer
 
 **Language:** C++  
 **Version:** `v0.1.0`

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -142,6 +142,9 @@ int main() {
   }
 
   // Check if the audio format is supported by the default output device.
+  //
+  // Safe conversion of sample_rate: MP3 sample rates are well below precision
+  // limits of double
   if (Pa_IsFormatSupported(nullptr, &output_parameters, sample_rate) !=
       paFormatIsSupported) {
     std::cerr
@@ -162,6 +165,9 @@ int main() {
   // ---------------------------
 
   // Open the audio stream.
+  //
+  // Safe conversion of sample_rate: MP3 sample rates are well below precision
+  // limits of double
   portaudio_error =
       Pa_OpenStream(&audio_stream,
                     nullptr,  // No input.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,7 +38,7 @@ int main() {
 
   // Check if decoder was created successfully.
   if (decoder == nullptr) {
-    std::cerr << "decoder = nullptr\n";
+    std::cerr << "Failed to create decoder.\n";
 
     return 1;
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,11 +34,11 @@ int main() {
   // Create a new mpg123 handle.
   int mpg123_error;
 
-  mpg123_handle* decoder = mpg123_new(NULL, &mpg123_error);
+  mpg123_handle* decoder = mpg123_new(nullptr, &mpg123_error);
 
   // Check if decoder was created successfully.
-  if (decoder == NULL) {
-    std::cerr << "decoder = NULL\n";
+  if (decoder == nullptr) {
+    std::cerr << "decoder = nullptr\n";
 
     return 1;
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,7 +56,8 @@ int main() {
 
   // Get the format data needed to set the output format.
   long sample_rate;
-  int channels, encoding_format;
+  int channels;
+  int encoding_format;
 
   mpg123_getformat(decoder, &sample_rate, &channels, &encoding_format);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -234,7 +234,7 @@ int main() {
   // bytes_read bytes of PCM data.
   while ((mpg123_error = mpg123_read(decoder, buffer, buffer_size,
                                      &bytes_read)) == MPG123_OK) {
-    int frames = bytes_read / frame_size;
+    size_t frames = bytes_read / frame_size;
 
     portaudio_error = Pa_WriteStream(audio_stream, buffer, frames);
 


### PR DESCRIPTION
- Refactored code for consistency (changed `frames` type to `size_t`)
- Improved code readability and error handling (e.g., separated variable declarations, replaced `NULL` with `nullptr`)
- Added comments explaining safe type conversion for MP3 sample rates
- Removed language from README.md title for brevity