### PR TITLE
Refactor/cleanup handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2025-09-02
+### Refactor
+- Centralized cleanup logic to reduce repetition and improve safety
+- Introduced RAII wrappers for `mpg123_new()`, `Pa_Initialize()` and `Pa_OpenStream()`
+- Refactored buffer allocation to use std::vector for RAII
+
+### Style
+- Internal code cleanup for clarity and consistency
+
 ## [0.1.1] - 2025-08-30
 ### Refactor
 - Refactored code for consistency (changed `frames` type to `size_t`)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Project setup
-project(mp3_audio_analyzer VERSION 0.1.1 LANGUAGES CXX)
+project(mp3_audio_analyzer VERSION 0.1.2 LANGUAGES CXX)
 
 # C++17 standard required
 set(CMAKE_CXX_STANDARD 17)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MP3 Audio Analyzer
 
 **Language:** C++  
-**Version:** `v0.1.1`
+**Version:** `v0.1.2`
 
 A real-time MP3 audio analyzer (in development) using [mpg123](https://www.mpg123.de/) and [PortAudio](http://www.portaudio.com/).
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -120,10 +120,10 @@ int main() {
   int mpg123_error;
   Mpg123Decoder decoder;
 
-  auto* handle = decoder.handle();
+  auto* decoder_handle = decoder.handle();
 
   // Check if handle was created successfully.
-  if (handle == nullptr) {
+  if (decoder_handle == nullptr) {
     std::cerr << "Failed to create handle. Error: "
               << mpg123_plain_strerror(decoder.error()) << "\n";
 
@@ -131,7 +131,8 @@ int main() {
   }
 
   // Open the MP3 file.
-  if (mpg123_open(handle, "../assets/gradient_deep_performance_edit.mp3") !=
+  if (mpg123_open(decoder_handle,
+                  "../assets/gradient_deep_performance_edit.mp3") !=
       MPG123_OK) {
     std::cerr << "Failed to open file.\n";
 
@@ -143,12 +144,13 @@ int main() {
   int channels;
   int encoding_format;
 
-  mpg123_getformat(handle, &sample_rate, &channels, &encoding_format);
+  mpg123_getformat(decoder_handle, &sample_rate, &channels, &encoding_format);
 
   // Allocate a buffer.
   size_t buffer_size;
 
-  buffer_size = mpg123_outblock(handle);  // Get the recommended buffer size.
+  buffer_size =
+      mpg123_outblock(decoder_handle);  // Get the recommended buffer size.
   std::vector<unsigned char> buffer(buffer_size);
 
   // ---------------------------
@@ -250,7 +252,7 @@ int main() {
   //
   // This loop runs until the MP3 is fully decoded. The buffer contains
   // bytes_read bytes of PCM data.
-  while ((mpg123_error = mpg123_read(handle, buffer.data(), buffer_size,
+  while ((mpg123_error = mpg123_read(decoder_handle, buffer.data(), buffer_size,
                                      &bytes_read)) == MPG123_OK) {
     size_t frames = bytes_read / frame_size;
 
@@ -268,7 +270,7 @@ int main() {
   if (mpg123_error == MPG123_DONE) {
     std::cout << "Finished decoding successfully.\n";
   } else if (mpg123_error != MPG123_OK) {
-    std::cerr << "Decoding failed. Error: " << mpg123_strerror(handle)
+    std::cerr << "Decoding failed. Error: " << mpg123_strerror(decoder_handle)
               << " (code " << mpg123_error << ")\n";
 
     return 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include <portaudio.h>
 
 #include <iostream>
+#include <vector>
 
 // Converts an mpg123 encoding format to a compatible PortAudio sample format.
 // The input is the encoding value returned by mpg123_getformat().
@@ -62,22 +63,10 @@ int main() {
   mpg123_getformat(decoder, &sample_rate, &channels, &encoding_format);
 
   // Allocate a buffer.
-  unsigned char* buffer;
   size_t buffer_size;
 
   buffer_size = mpg123_outblock(decoder);  // Get the recommended buffer size.
-  buffer =
-      static_cast<unsigned char*>(malloc(buffer_size * sizeof(unsigned char)));
-
-  if (buffer == nullptr) {
-    std::cerr << "Failed to allocate buffer.\n";
-
-    // Clean up.
-    mpg123_close(decoder);
-    mpg123_delete(decoder);
-
-    return 1;
-  }
+  std::vector<unsigned char> buffer(buffer_size);
 
   // ---------------------------
   // Configure and open output stream
@@ -94,7 +83,6 @@ int main() {
               << " (code : " << portaudio_error << ")\n";
 
     // Clean up.
-    free(buffer);
     mpg123_close(decoder);
     mpg123_delete(decoder);
 
@@ -113,7 +101,6 @@ int main() {
     // Clean up.
     Pa_Terminate();
 
-    free(buffer);
     mpg123_close(decoder);
     mpg123_delete(decoder);
 
@@ -134,7 +121,6 @@ int main() {
     // Clean up.
     Pa_Terminate();
 
-    free(buffer);
     mpg123_close(decoder);
     mpg123_delete(decoder);
 
@@ -153,7 +139,6 @@ int main() {
     // Clean up.
     Pa_Terminate();
 
-    free(buffer);
     mpg123_close(decoder);
     mpg123_delete(decoder);
 
@@ -184,7 +169,6 @@ int main() {
     // Clean up.
     Pa_Terminate();
 
-    free(buffer);
     mpg123_close(decoder);
     mpg123_delete(decoder);
 
@@ -201,7 +185,6 @@ int main() {
     Pa_CloseStream(audio_stream);
     Pa_Terminate();
 
-    free(buffer);
     mpg123_close(decoder);
     mpg123_delete(decoder);
 
@@ -225,7 +208,6 @@ int main() {
     Pa_CloseStream(audio_stream);
     Pa_Terminate();
 
-    free(buffer);
     mpg123_close(decoder);
     mpg123_delete(decoder);
 
@@ -238,11 +220,11 @@ int main() {
   //
   // This loop runs until the MP3 is fully decoded. The buffer contains
   // bytes_read bytes of PCM data.
-  while ((mpg123_error = mpg123_read(decoder, buffer, buffer_size,
+  while ((mpg123_error = mpg123_read(decoder, buffer.data(), buffer_size,
                                      &bytes_read)) == MPG123_OK) {
     size_t frames = bytes_read / frame_size;
 
-    portaudio_error = Pa_WriteStream(audio_stream, buffer, frames);
+    portaudio_error = Pa_WriteStream(audio_stream, buffer.data(), frames);
 
     if (portaudio_error != paNoError) {
       std::cerr << "PortAudio write error: " << Pa_GetErrorText(portaudio_error)
@@ -263,7 +245,6 @@ int main() {
     Pa_CloseStream(audio_stream);
     Pa_Terminate();
 
-    free(buffer);
     mpg123_close(decoder);
     mpg123_delete(decoder);
 
@@ -278,7 +259,6 @@ int main() {
   Pa_CloseStream(audio_stream);
   Pa_Terminate();
 
-  free(buffer);
   mpg123_close(decoder);
   mpg123_delete(decoder);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,12 +56,15 @@ class PortAudioSystem {
   bool initialized_ = false;
 };
 
+// AudioStream is an RAII wrapper class around Pa_OpenStream()
+// that manages audio stream opening and cleanup.
 class AudioStream {
  public:
   AudioStream(PaStreamParameters output_parameters, long sample_rate) {
     // Open the audio stream.
+    //
     // Safe conversion of sample_rate: MP3 sample rates are well below precision
-    // limits of double
+    // limits of double.
     error_ =
         Pa_OpenStream(&stream_,
                       nullptr,  // No input.
@@ -91,6 +94,7 @@ class AudioStream {
 };
 
 // Converts an mpg123 encoding format to a compatible PortAudio sample format.
+//
 // The input is the encoding value returned by mpg123_getformat().
 PaSampleFormat GetPortAudioFormat(int mpg123_encoding) {
   switch (mpg123_encoding) {
@@ -193,7 +197,7 @@ int main() {
   // Check if the audio format is supported by the default output device.
   //
   // Safe conversion of sample_rate: MP3 sample rates are well below precision
-  // limits of double
+  // limits of double.
   if (Pa_IsFormatSupported(nullptr, &output_parameters, sample_rate) !=
       paFormatIsSupported) {
     std::cerr


### PR DESCRIPTION
### Refactor
- Centralized cleanup logic to reduce repetition and improve safety
- Introduced RAII wrappers for `mpg123_new()`, `Pa_Initialize()` and `Pa_OpenStream()`
- Refactored buffer allocation to use std::vector for RAII

### Style
- Internal code cleanup for clarity and consistency