### PR TITLE
Fix audio glitches by setting framesPerBuffer to 512

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.1.5] - 2025-09-10
+### Fixed
+- Audio glitches at startup and during volume changes resolved by setting `framesPerBuffer` to 512 instead of using `paFramesPerBufferUnspecified`
+
 ## [v0.1.4] – 2025-09-10
 ### Changed
 - Rename `Mpg123Decoder` to `Mpg123HandleWrapper` for clarity

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Project setup
-project(mp3_audio_analyzer VERSION 0.1.4 LANGUAGES CXX)
+project(mp3_audio_analyzer VERSION 0.1.5 LANGUAGES CXX)
 
 # C++17 standard required
 set(CMAKE_CXX_STANDARD 17)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MP3 Audio Analyzer
 
 **Language:** C++  
-**Version:** `v0.1.4`
+**Version:** `v0.1.5`
 
 A real-time MP3 audio analyzer (in development) using [mpg123](https://www.mpg123.de/) and [PortAudio](http://www.portaudio.com/).
 
@@ -102,8 +102,8 @@ project-root/
 
 ## To Do
 
-- [ ] Fix audio glitches
-- [ ] Investigate buffer underruns or latency issues
+- [x] Fix audio glitches
+- [x] Investigate buffer underruns or latency issues
 - [x] Refactor cleanup logic
 - [x] Refactor error handling into reusable functions
 - [x] Refactor audio logic into classes

--- a/src/audio_output.cpp
+++ b/src/audio_output.cpp
@@ -35,15 +35,16 @@ int PortAudioSystem::error() const {
 
 AudioStream::AudioStream(const PaStreamParameters& output_parameters,
                          long sample_rate) {
+  constexpr unsigned long kFramesPerBuffer = 512;
+
   // Safe conversion of sample_rate_: MP3 sample rates are well below
   // precision limits of double.
   error_ = Pa_OpenStream(&stream_,
                          nullptr,  // No input.
-                         &output_parameters, sample_rate,
-                         paFramesPerBufferUnspecified,  // Let PortAudio decide.
-                         paClipOff,                     // No clipping.
-                         nullptr,                       // No callback.
-                         nullptr);  // No callback user data.
+                         &output_parameters, sample_rate, kFramesPerBuffer,
+                         paClipOff,  // No clipping.
+                         nullptr,    // No callback.
+                         nullptr);   // No callback user data.
 }
 
 AudioStream::~AudioStream() {


### PR DESCRIPTION
This PR addresses audio glitching issues that occurred when using `paFramesPerBufferUnspecified` in the PortAudio stream configuration.

### Symptoms
- Glitches at the beginning of playback
- Glitches when adjusting system volume via keyboard

### Fix
- Set `framesPerBuffer` to a fixed value of 512
- Playback is now smooth with no noticeable increase in latency

### Root Cause Analysis
- Investigated buffer underruns and latency issues through logging
- PortAudio returned no errors during playback
- Setting a fixed buffer size resolves the issue, implying buffer underruns were the likely cause

This completes the TODO tasks:
- [x] Fix audio glitches  
- [x] Investigate buffer underruns or latency issues