### PR TITLE
Add AnalysisThread scaffolding (no FFTW yet)

### DIFF
--- a/include/analysis_thread.h
+++ b/include/analysis_thread.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 Kars Helderman
+// SPDX-License-Identifier: MIT
+//
+// Declaration of AnalysisThread class. Creates a thread for reading audio data
+// from a ring buffer and performing analysis using FFTW.
+
+#pragma once
+
+#include <atomic>
+#include <thread>
+
+#include "ring_buffer.h"
+
+// Initialize() must be called right after the constructor.
+class AnalysisThread {
+ public:
+  AnalysisThread();
+  ~AnalysisThread();
+
+  bool Initialize();
+
+  RingBuffer<float>& buffer();  // So producer can write into it.
+
+ private:
+  void Start();
+  void Stop();
+  void Run();
+
+  std::thread thread_;
+  std::atomic<bool> running_;
+  RingBuffer<float> buffer_;
+};

--- a/src/analysis_thread.cpp
+++ b/src/analysis_thread.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2025 Kars Helderman
+// SPDX-License-Identifier: MIT
+//
+// Implementation of AnalysisThread class.
+
+#include "analysis_thread.h"
+
+#include <thread>
+
+#include "ring_buffer.h"
+
+namespace {
+constexpr size_t kDefaultCapacity = 2048;
+}
+
+AnalysisThread::AnalysisThread() {}
+
+AnalysisThread::~AnalysisThread() {
+  Stop();
+}
+
+bool AnalysisThread::Initialize() {
+  if (!buffer_.Initialize(kDefaultCapacity)) {
+    return false;
+  }
+
+  Start();
+
+  return true;
+}
+
+RingBuffer<float>& AnalysisThread::buffer() {
+  return buffer_;
+}
+
+void AnalysisThread::Start() {
+  running_ = true;
+  thread_ = std::thread(&AnalysisThread::Run, this);
+}
+
+void AnalysisThread::Stop() {
+  running_ = false;
+
+  if (thread_.joinable()) {
+    thread_.join();
+  }
+}
+
+void AnalysisThread::Run() {
+  while (running_) {
+    // TODO: Read ring buffer and write to FFTW.
+    // TODO: Add analysis logic.
+  }
+}


### PR DESCRIPTION
Adds the `AnalysisThread` class with RAII-based thread lifecycle management.

- Initializes an internal `RingBuffer<float>` with default capacity
- Starts a background thread in `Initialize()` and joins it in the destructor
- Intended to be used for real-time audio analysis (e.g., FFT)
- The thread currently has no analysis logic — FFTW integration will follow in a separate PR